### PR TITLE
switch tests to use mimetypes

### DIFF
--- a/tests/test_govukassets.py
+++ b/tests/test_govukassets.py
@@ -1,5 +1,6 @@
 from tests.helpers import with_client, setUpApp, with_context
 import unittest
+import mimetypes
 
 
 class TestGovukAssets (unittest.TestCase):
@@ -12,20 +13,21 @@ class TestGovukAssets (unittest.TestCase):
     def test_image(self, client):
         res = client.get('/template/assets/images/favicon.ico')
         self.assertEqual(res.status_code, 200)
-        self.assertIn("image/x-icon", res.headers['Content-Type'])
+        icon_type = mimetypes.guess_type('favicon.ico')[0]
+        self.assertIn(icon_type, res.headers['Content-Type'])
 
     @with_context
     @with_client
     def test_css(self, client):
         res = client.get('/template/assets/stylesheets/govuk-template.css')
         self.assertEqual(res.status_code, 200)
-        self.assertIn("text/css", res.headers['Content-Type'])
+        css_type = mimetypes.guess_type('govuk-template.css')[0]
+        self.assertIn(css_type, res.headers['Content-Type'])
 
     @with_context
     @with_client
     def test_js(self, client):
         res = client.get('/template/assets/javascripts/govuk-template.js')
         self.assertEqual(res.status_code, 200)
-        self.assertIn(
-            "application/javascript", res.headers['Content-Type']
-        )
+        js_type = mimetypes.guess_type('govuk-template.js')[0]
+        self.assertIn(js_type, res.headers['Content-Type'])


### PR DESCRIPTION
Weirdly pythons built in module `mimetypes` makes different guesses on
the type of a file depending on environment. So using Python 3.4.3 on
both ubuntu and mac osx results in 'image/x-icon' and
'image/vnd.microsoft.icon'.

To solve this I've switched to using mimetypes so the two answers should
match. Should be ok as this test is only proving that the correct format
result was returned, i.e. not js when we asked for css.
